### PR TITLE
Repaire add zone

### DIFF
--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SimulationContextController.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SimulationContextController.java
@@ -65,7 +65,7 @@ public class SimulationContextController {
      */
     @PostMapping(value = "/setOutsideTemp")
     @ResponseStatus(value = HttpStatus.OK)
-    public boolean setOutsideTemp(@RequestParam("outsideTemp") int outsideTemp) {
+    public boolean setOutsideTemp(@RequestParam("outsideTemp") double outsideTemp) {
        return simulationContextService.setOutsideTemp(outsideTemp);
     }
 

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SimulationContextController.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SimulationContextController.java
@@ -1,6 +1,7 @@
 package com.project.SmartHomeSimulator.api;
 
 import com.project.SmartHomeSimulator.model.HomeLayout;
+import com.project.SmartHomeSimulator.model.ResponseParameters;
 import com.project.SmartHomeSimulator.module.SimulationContext;
 import com.project.SmartHomeSimulator.service.SimulationContextService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +24,8 @@ public class SimulationContextController {
      */
     @PostMapping(value = "/start")
     @ResponseStatus(value = HttpStatus.OK)
-    public void startSimulation() {
-        simulationContextService.startSimulation();
+    public ResponseParameters startSimulation() {
+        return simulationContextService.startSimulation();
     }
 
     /**
@@ -111,5 +112,4 @@ public class SimulationContextController {
     public boolean setAutomode(@RequestParam("autoMode") boolean autoMode) {
         return simulationContextService.setAutoMode(autoMode);
     }
-
 }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SmartHomeHeatingController.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SmartHomeHeatingController.java
@@ -1,7 +1,9 @@
 package com.project.SmartHomeSimulator.api;
 
-import com.project.SmartHomeSimulator.model.ResponseAPI;
-import com.project.SmartHomeSimulator.model.Zone;
+import com.project.SmartHomeSimulator.model.*;
+import com.project.SmartHomeSimulator.model.Zones.CompleteZones;
+import com.project.SmartHomeSimulator.model.Zones.Zone;
+import com.project.SmartHomeSimulator.model.Zones.ZoneObject;
 import com.project.SmartHomeSimulator.module.*;
 import com.project.SmartHomeSimulator.service.SmartHomeHeatingService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 /**
  * API controller for everything related to the heating process
@@ -257,5 +260,11 @@ public class SmartHomeHeatingController {
     @ResponseStatus(value = HttpStatus.OK)
     public void setSeason(@RequestParam("isSummer") boolean isSummer) {
         smartHomeHeatingService.setSeason(isSummer);
+    }
+
+    @GetMapping(value = "/getAllZones")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<ZoneObject> getAllZones(){
+        return CompleteZones.zones;
     }
 }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SmartHomeHeatingController.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SmartHomeHeatingController.java
@@ -62,7 +62,7 @@ public class SmartHomeHeatingController {
      */
     @PostMapping(value = "/changeRoomTemp")
     @ResponseStatus(value = HttpStatus.OK)
-    public ResponseAPI changeRoomTemp(@RequestParam("roomName") String roomName, @RequestParam("newTemp") int newTemp) {
+    public ResponseAPI changeRoomTemp(@RequestParam("roomName") String roomName, @RequestParam("newTemp") double newTemp) {
         ResponseAPI response = new ResponseAPI();
         response.setDefaultValues();
         if (smartHomeSecurity.getAwayModeConfig().isAwayMode()
@@ -184,7 +184,7 @@ public class SmartHomeHeatingController {
      */
     @PostMapping(value = "/setSummerTemperature")
     @ResponseStatus(value = HttpStatus.OK)
-    public boolean setSummerTemperature(@RequestParam("temperature") int temperature) {
+    public boolean setSummerTemperature(@RequestParam("temperature") double temperature) {
         simulationContext.setSummerTemp(temperature);
         return true;
     }
@@ -197,7 +197,7 @@ public class SmartHomeHeatingController {
      */
     @PostMapping(value = "/setWinterTemperature")
     @ResponseStatus(value = HttpStatus.OK)
-    public boolean setWinterTemperature(@RequestParam("temperature") int temperature) {
+    public boolean setWinterTemperature(@RequestParam("temperature") double temperature) {
         simulationContext.setWinterTemp(temperature);
         return true;
     }
@@ -230,7 +230,7 @@ public class SmartHomeHeatingController {
      */
     @PostMapping(value = "/setTempThreshold")
     @ResponseStatus(value = HttpStatus.OK)
-    public boolean setTempThreshold(@RequestParam("tempThreshold") int tempThreshold) {
+    public boolean setTempThreshold(@RequestParam("tempThreshold") double tempThreshold) {
         simulationContext.setTempThreshold(tempThreshold);
         return true;
     }
@@ -279,7 +279,7 @@ public class SmartHomeHeatingController {
      */
     @PostMapping(value = "/setCurrentTemp")
     @ResponseStatus(value = HttpStatus.OK)
-    public boolean setCurrentTemp(@RequestParam("roomName") String roomName, @RequestParam("currentTemp") int currentTemp) {
+    public boolean setCurrentTemp(@RequestParam("roomName") String roomName, @RequestParam("currentTemp") double currentTemp) {
         return smartHomeHeatingService.setCurrentTemp(roomName,currentTemp);
     }
 }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SmartHomeHeatingController.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/api/SmartHomeHeatingController.java
@@ -262,9 +262,24 @@ public class SmartHomeHeatingController {
         smartHomeHeatingService.setSeason(isSummer);
     }
 
+    /**
+     * Gets all the zones with the rooms inside
+     * @return
+     */
     @GetMapping(value = "/getAllZones")
     @ResponseStatus(value = HttpStatus.OK)
     public List<ZoneObject> getAllZones(){
         return CompleteZones.zones;
+    }
+
+    /**
+     * Set the currentTemp of a room
+     * @param roomName
+     * @param currentTemp
+     */
+    @PostMapping(value = "/setCurrentTemp")
+    @ResponseStatus(value = HttpStatus.OK)
+    public boolean setCurrentTemp(@RequestParam("roomName") String roomName, @RequestParam("currentTemp") int currentTemp) {
+        return smartHomeHeatingService.setCurrentTemp(roomName,currentTemp);
     }
 }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/HomeLayout.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/HomeLayout.java
@@ -20,6 +20,7 @@ public class HomeLayout {
     private static int lightCount = 1;
     private static int acCount = 1;
     private static int heaterCount =1;
+    public static int roomsNotInZone;
     /**
      * Gets a room by name
      *
@@ -88,6 +89,7 @@ public class HomeLayout {
             outside.setObjects(objects);
             rooms.add(outside);
             homeLayout.setRoomList(rooms);
+            roomsNotInZone = rooms.size() - 2;
             return homeLayout;
         } catch (JsonProcessingException e) {
             e.printStackTrace();

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/ResponseParameters.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/ResponseParameters.java
@@ -1,0 +1,14 @@
+package com.project.SmartHomeSimulator.model;
+
+public class ResponseParameters {
+    public boolean allowed;
+    public String consoleMessage;
+
+    public void setAllowed(boolean allowed) {
+        this.allowed = allowed;
+    }
+
+    public void setConsoleMessage(String consoleMessage) {
+        this.consoleMessage = consoleMessage;
+    }
+}

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Room.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Room.java
@@ -18,8 +18,8 @@ public class Room {
     private List<RoomObject> roomObjects;
     private String zone;
     private boolean overridden = false;
-    private int currentTemp;
-    private int desiredTemp;
+    private double currentTemp;
+    private double desiredTemp;
     private String period1;
     private int period1Temp;
     private String period2;
@@ -28,11 +28,11 @@ public class Room {
     private int period3Temp;
     private int usersInRoom;
 
-    public int getDesiredTemp() {
+    public double getDesiredTemp() {
         return desiredTemp;
     }
 
-    public void setDesiredTemp(int desiredTemp) {
+    public void setDesiredTemp(double desiredTemp) {
         this.desiredTemp = desiredTemp;
     }
 
@@ -127,11 +127,11 @@ public class Room {
         return usersInRoom;
     }
 
-    public int getCurrentTemp() {
+    public double getCurrentTemp() {
         return currentTemp;
     }
 
-    public void setCurrentTemp(int currentTemp) {
+    public void setCurrentTemp(double currentTemp) {
         this.currentTemp = currentTemp;
     }
 

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Room.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Room.java
@@ -19,12 +19,15 @@ public class Room {
     private String zone;
     private boolean overridden = false;
     private int currentTemp;
+    private int nonEmptyTemp;
+    private int emptyTemp;
     private String period1;
     private int period1Temp;
     private String period2;
     private int period2Temp;
     private String period3;
     private int period3Temp;
+    private int usersInRoom;
 
     public String getPeriod1() {
         return period1;
@@ -74,12 +77,20 @@ public class Room {
         this.period3Temp = period3Temp;
     }
 
-    public int getCurrentTemp() {
-        return currentTemp;
+    public int getNonEmptyTemp() {
+        return nonEmptyTemp;
     }
 
-    public void setCurrentTemp(int currentTemp) {
-        this.currentTemp = currentTemp;
+    public void setNonEmptyTemp(int nonEmptyTemp) {
+        this.nonEmptyTemp = nonEmptyTemp;
+    }
+
+    public int getEmptyTemp() {
+        return emptyTemp;
+    }
+
+    public void setEmptyTemp(int emptyTemp) {
+        this.emptyTemp = emptyTemp;
     }
 
     public boolean isOverridden() {
@@ -112,6 +123,25 @@ public class Room {
 
     public void setObjects(List<RoomObject> roomObjects) {
         this.roomObjects = roomObjects;
+    }
+
+    public void incrementUsersInRoom(){
+        usersInRoom++;
+    }
+    public void decrementUsersInRoom(){
+        usersInRoom--;
+    }
+
+    public int getUsersInRoom() {
+        return usersInRoom;
+    }
+
+    public int getCurrentTemp() {
+        return currentTemp;
+    }
+
+    public void setCurrentTemp(int currentTemp) {
+        this.currentTemp = currentTemp;
     }
 
     /**

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Room.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Room.java
@@ -19,8 +19,7 @@ public class Room {
     private String zone;
     private boolean overridden = false;
     private int currentTemp;
-    private int nonEmptyTemp;
-    private int emptyTemp;
+    private int desiredTemp;
     private String period1;
     private int period1Temp;
     private String period2;
@@ -28,6 +27,14 @@ public class Room {
     private String period3;
     private int period3Temp;
     private int usersInRoom;
+
+    public int getDesiredTemp() {
+        return desiredTemp;
+    }
+
+    public void setDesiredTemp(int desiredTemp) {
+        this.desiredTemp = desiredTemp;
+    }
 
     public String getPeriod1() {
         return period1;
@@ -75,22 +82,6 @@ public class Room {
 
     public void setPeriod3Temp(int period3Temp) {
         this.period3Temp = period3Temp;
-    }
-
-    public int getNonEmptyTemp() {
-        return nonEmptyTemp;
-    }
-
-    public void setNonEmptyTemp(int nonEmptyTemp) {
-        this.nonEmptyTemp = nonEmptyTemp;
-    }
-
-    public int getEmptyTemp() {
-        return emptyTemp;
-    }
-
-    public void setEmptyTemp(int emptyTemp) {
-        this.emptyTemp = emptyTemp;
     }
 
     public boolean isOverridden() {

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zone.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zone.java
@@ -10,7 +10,8 @@ import java.util.List;
 public class Zone {
     private String name;
     private List<String> roomsInZone;
-    private int currentTemp;
+    private int nonEmptyTemp;
+    private int emptyTemp;
     private String period1;
     private int period1Temp;
     private String period2;
@@ -30,16 +31,24 @@ public class Zone {
         return roomsInZone;
     }
 
+    public int getNonEmptyTemp() {
+        return nonEmptyTemp;
+    }
+
+    public void setNonEmptyTemp(int nonEmptyTemp) {
+        this.nonEmptyTemp = nonEmptyTemp;
+    }
+
+    public int getEmptyTemp() {
+        return emptyTemp;
+    }
+
+    public void setEmptyTemp(int emptyTemp) {
+        this.emptyTemp = emptyTemp;
+    }
+
     public void setRoomsInZone(List<String> roomsInZone) {
         this.roomsInZone = roomsInZone;
-    }
-
-    public int getCurrentTemp() {
-        return currentTemp;
-    }
-
-    public void setCurrentTemp(int currentTemp) {
-        this.currentTemp = currentTemp;
     }
 
     public String getPeriod1() {

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/CompleteZones.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/CompleteZones.java
@@ -1,0 +1,8 @@
+package com.project.SmartHomeSimulator.model.Zones;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompleteZones {
+    public static List<ZoneObject> zones = new ArrayList<>();;
+}

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/Zone.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/Zone.java
@@ -10,8 +10,7 @@ import java.util.List;
 public class Zone {
     private String name;
     private List<String> roomsInZone;
-    private int nonEmptyTemp;
-    private int emptyTemp;
+    private int desiredTemp;
     private String period1;
     private int period1Temp;
     private String period2;
@@ -31,20 +30,12 @@ public class Zone {
         return roomsInZone;
     }
 
-    public int getNonEmptyTemp() {
-        return nonEmptyTemp;
+    public int getDesiredTemp() {
+        return desiredTemp;
     }
 
-    public void setNonEmptyTemp(int nonEmptyTemp) {
-        this.nonEmptyTemp = nonEmptyTemp;
-    }
-
-    public int getEmptyTemp() {
-        return emptyTemp;
-    }
-
-    public void setEmptyTemp(int emptyTemp) {
-        this.emptyTemp = emptyTemp;
+    public void setDesiredTemp(int desiredTemp) {
+        this.desiredTemp = desiredTemp;
     }
 
     public void setRoomsInZone(List<String> roomsInZone) {

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/Zone.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/Zone.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class Zone {
     private String name;
     private List<String> roomsInZone;
-    private int desiredTemp;
+    private double desiredTemp;
     private String period1;
     private int period1Temp;
     private String period2;
@@ -30,11 +30,11 @@ public class Zone {
         return roomsInZone;
     }
 
-    public int getDesiredTemp() {
+    public double getDesiredTemp() {
         return desiredTemp;
     }
 
-    public void setDesiredTemp(int desiredTemp) {
+    public void setDesiredTemp(double desiredTemp) {
         this.desiredTemp = desiredTemp;
     }
 

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/Zone.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/Zone.java
@@ -1,4 +1,4 @@
-package com.project.SmartHomeSimulator.model;
+package com.project.SmartHomeSimulator.model.Zones;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.springframework.boot.jackson.JsonComponent;

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/ZoneObject.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/model/Zones/ZoneObject.java
@@ -1,0 +1,25 @@
+package com.project.SmartHomeSimulator.model.Zones;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ZoneObject {
+    private String zoneName;
+    private List<String> rooms = new ArrayList<>();
+
+    public String getZoneName() {
+        return zoneName;
+    }
+
+    public void setZoneName(String zoneName) {
+        this.zoneName = zoneName;
+    }
+
+    public List<String> getRooms() {
+        return rooms;
+    }
+
+    public void setRooms(List<String> rooms) {
+        this.rooms = rooms;
+    }
+}

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
@@ -188,6 +188,7 @@ public class SimulationContext {
 				if(!user.getHomeLocation().equalsIgnoreCase("outside")) {
 					HomeLayout.usersInHome++;
 				}
+				homeLayout.getRoomByName(user.getHomeLocation()).incrementUsersInRoom();
 			}
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
@@ -18,8 +18,8 @@ public class SimulationContext {
 
 	public static SimulationContext simulationContext = null;
 	private boolean simulationRunning;
-	private int outsideTemp;
-	private int emptyRoomTemp;
+	private double outsideTemp;
+	private double emptyRoomTemp;
 	private String time;
 	private String date;
 	private User currentSimulationUser;
@@ -34,10 +34,10 @@ public class SimulationContext {
 	private List<Monitor> monitors;
 	private String summerMonths;
 	private String winterMonths;
-	private int summerTemp;
-	private int winterTemp;
+	private double summerTemp;
+	private double winterTemp;
 	private final File userProfilesJSON = new File("./src/main/resources/user_profiles.json.txt");
-	private int tempThreshold;
+	private double tempThreshold;
 
 	private SimulationContext() {
 		loadUserProfiles();
@@ -53,27 +53,27 @@ public class SimulationContext {
 		return simulationContext;
 	}
 
-	public int getEmptyRoomTemp() {
+	public double getEmptyRoomTemp() {
 		return emptyRoomTemp;
 	}
 
-	public void setEmptyRoomTemp(int emptyRoomTemp) {
+	public void setEmptyRoomTemp(double emptyRoomTemp) {
 		this.emptyRoomTemp = emptyRoomTemp;
 	}
 
-	public int getSummerTemp() {
+	public double getSummerTemp() {
 		return summerTemp;
 	}
 
-	public void setSummerTemp(int summerTemp) {
+	public void setSummerTemp(double summerTemp) {
 		this.summerTemp = summerTemp;
 	}
 
-	public int getWinterTemp() {
+	public double getWinterTemp() {
 		return winterTemp;
 	}
 
-	public void setWinterTemp(int winterTemp) {
+	public void setWinterTemp(double winterTemp) {
 		this.winterTemp = winterTemp;
 	}
 
@@ -113,11 +113,11 @@ public class SimulationContext {
 		return timeBeforeAuthoroties;
 	}
 
-	public int getTempThreshold() {
+	public double getTempThreshold() {
 		return tempThreshold;
 	}
 
-	public void setTempThreshold(int tempThreshold) {
+	public void setTempThreshold(double tempThreshold) {
 		this.tempThreshold = tempThreshold;
 	}
 
@@ -141,11 +141,11 @@ public class SimulationContext {
 		this.awayModeUser = awayModeUser;
 	}
 
-	public int getOutsideTemp() {
+	public double getOutsideTemp() {
 		return outsideTemp;
 	}
 
-	public void setOutsideTemp(int outsideTemp) {
+	public void setOutsideTemp(double outsideTemp) {
 		this.outsideTemp = outsideTemp;
 	}
 

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
@@ -19,6 +19,7 @@ public class SimulationContext {
 	public static SimulationContext simulationContext = null;
 	private boolean simulationRunning;
 	private int outsideTemp;
+	private int emptyRoomTemp;
 	private String time;
 	private String date;
 	private User currentSimulationUser;
@@ -50,6 +51,14 @@ public class SimulationContext {
 			simulationContext = new SimulationContext();
 		}
 		return simulationContext;
+	}
+
+	public int getEmptyRoomTemp() {
+		return emptyRoomTemp;
+	}
+
+	public void setEmptyRoomTemp(int emptyRoomTemp) {
+		this.emptyRoomTemp = emptyRoomTemp;
 	}
 
 	public int getSummerTemp() {
@@ -116,16 +125,6 @@ public class SimulationContext {
 		this.timeBeforeAuthoroties = timeBeforeAuthoroties;
 	}
 
-	public List<User> getAllUsersInLocation(String room){
-		List<User> usersInRoom = new ArrayList<>();
-		for (User user : this.simulationUsers){
-			if(user.getHomeLocation().equalsIgnoreCase(room)){
-				usersInRoom.add(user);
-			}
-		}
-		return usersInRoom;
-	}
-
 	public boolean isAutoMode() {
 		return autoMode;
 	}
@@ -177,19 +176,6 @@ public class SimulationContext {
 	public List<User> getSimulationUsers() {
 		return simulationUsers;
 	}
-	
-	public void loadUserProfiles() {
-		ObjectMapper mapper = new ObjectMapper();
-		
-		try {
-			simulationUsers = mapper.readValue(userProfilesJSON, new TypeReference<List<User>>(){});
-			for (User user : simulationUsers){
-				user.setHomeLocation("outside");
-			}
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
 
 	public void setSimulationUsers(List<User> simulationUsers) {
 		this.simulationUsers = simulationUsers;
@@ -219,20 +205,43 @@ public class SimulationContext {
 		this.monitors.remove(monitor);
 	}
 
-	public void notifyMonitors(User user){
-		if (awayModeUser != null) {
-			for (Monitor monitor : this.monitors) {
-				monitor.update(awayModeUser.getName(), user);
-			}
-		}
-	}
-
 	public boolean isAwayMode() {
 		return awayMode;
 	}
 
 	public void setAwayMode(boolean awayMode) {
 		this.awayMode = awayMode;
+	}
+
+	public List<User> getAllUsersInLocation(String room){
+		List<User> usersInRoom = new ArrayList<>();
+		for (User user : this.simulationUsers){
+			if(user.getHomeLocation().equalsIgnoreCase(room)){
+				usersInRoom.add(user);
+			}
+		}
+		return usersInRoom;
+	}
+	
+	public void loadUserProfiles() {
+		ObjectMapper mapper = new ObjectMapper();
+		
+		try {
+			simulationUsers = mapper.readValue(userProfilesJSON, new TypeReference<List<User>>(){});
+			for (User user : simulationUsers){
+				user.setHomeLocation("outside");
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void notifyMonitors(User user){
+		if (awayModeUser != null) {
+			for (Monitor monitor : this.monitors) {
+				monitor.update(awayModeUser.getName(), user);
+			}
+		}
 	}
 
 	@Override

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SimulationContext.java
@@ -185,10 +185,7 @@ public class SimulationContext {
 		try {
 			simulationUsers = mapper.readValue(userProfilesJSON, new TypeReference<List<User>>(){});
 			for (User user : simulationUsers){
-				if(!user.getHomeLocation().equalsIgnoreCase("outside")) {
-					HomeLayout.usersInHome++;
-				}
-				homeLayout.getRoomByName(user.getHomeLocation()).incrementUsersInRoom();
+				user.setHomeLocation("outside");
 			}
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
@@ -39,10 +39,16 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
      */
     public boolean addZone(Zone zone) {
         for (String roomName : zone.getRoomsInZone()) {
+            int desiredTemp = zone.getEmptyTemp();
             Room room = SimulationContext.getInstance().getHomeLayout().getRoomByName(roomName);
+            if (room.getUsersInRoom() > 0){
+                desiredTemp = zone.getNonEmptyTemp();
+            }
             room.setZone(zone.getName());
-            switchStates(room, SimulationContext.getInstance().getOutsideTemp(), zone.getCurrentTemp());
-            room.setCurrentTemp(zone.getCurrentTemp());
+            switchStates(room, SimulationContext.getInstance().getOutsideTemp(), desiredTemp);
+            room.setCurrentTemp(desiredTemp);
+            room.setEmptyTemp(zone.getEmptyTemp());
+            room.setNonEmptyTemp(zone.getNonEmptyTemp());
             room.setPeriod1(zone.getPeriod1());
             room.setPeriod1Temp(zone.getPeriod1Temp());
             room.setPeriod2(zone.getPeriod2());

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
@@ -43,7 +43,7 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
             if(roomName.equalsIgnoreCase("backyard") || roomName.equalsIgnoreCase("outside")){
                 break;
             }
-            int desiredTemp = SimulationContext.getInstance().getEmptyRoomTemp();
+            double desiredTemp = SimulationContext.getInstance().getEmptyRoomTemp();
             Room room = SimulationContext.getInstance().getHomeLayout().getRoomByName(roomName);
             if (room.getUsersInRoom() > 0){
                 desiredTemp = zone.getDesiredTemp();
@@ -74,7 +74,7 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
      * @param newTemp
      * @return
      */
-    public boolean changeRoomTemp(String roomName, int newTemp) {
+    public boolean changeRoomTemp(String roomName, double newTemp) {
         Room room = SimulationContext.getInstance().getHomeLayout().getRoomByName(roomName);
         switchStates(room, room.getCurrentTemp(), newTemp);
         room.setOverridden(true);
@@ -124,7 +124,7 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
      * @param currentTemp
      * @param desiredTemp
      */
-    public void switchStates(Room room, int currentTemp, int desiredTemp) {
+    public void switchStates(Room room, double currentTemp, double desiredTemp) {
         Heater heater = (Heater) room.getRoomObjectByType(RoomObjectType.HEATER);
         AC ac = (AC) room.getRoomObjectByType(RoomObjectType.AC);
 
@@ -197,7 +197,7 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
      */
     public void adjustRoomTemperatures() {
         List<Room> rooms = SimulationContext.getInstance().getHomeLayout().getRoomList();
-        int newTemp;
+        double newTemp;
         if (isSummer) {
             newTemp = SimulationContext.getInstance().getSummerTemp();
         } else {

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
@@ -1,9 +1,9 @@
 package com.project.SmartHomeSimulator.module;
 
-import com.project.SmartHomeSimulator.model.HomeLayout;
-import com.project.SmartHomeSimulator.model.Room;
-import com.project.SmartHomeSimulator.model.User;
-import com.project.SmartHomeSimulator.model.Zone;
+import com.project.SmartHomeSimulator.model.*;
+import com.project.SmartHomeSimulator.model.Zones.CompleteZones;
+import com.project.SmartHomeSimulator.model.Zones.Zone;
+import com.project.SmartHomeSimulator.model.Zones.ZoneObject;
 import com.project.SmartHomeSimulator.model.roomObjects.*;
 
 import java.util.ArrayList;
@@ -38,7 +38,11 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
      * @return
      */
     public boolean addZone(Zone zone) {
+        ZoneObject zoneObject = new ZoneObject();
         for (String roomName : zone.getRoomsInZone()) {
+            if(roomName.equalsIgnoreCase("backyard") || roomName.equalsIgnoreCase("outside")){
+                break;
+            }
             int desiredTemp = zone.getEmptyTemp();
             Room room = SimulationContext.getInstance().getHomeLayout().getRoomByName(roomName);
             if (room.getUsersInRoom() > 0){
@@ -56,7 +60,11 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
             room.setPeriod3(zone.getPeriod3());
             room.setPeriod3Temp(zone.getPeriod3Temp());
             room.setOverridden(false);
+            HomeLayout.usersInHome--;
+            zoneObject.getRooms().add(roomName);
         }
+        zoneObject.setZoneName(zone.getName());
+        CompleteZones.zones.add(zoneObject);
         return true;
     }
 

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeating.java
@@ -43,16 +43,14 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
             if(roomName.equalsIgnoreCase("backyard") || roomName.equalsIgnoreCase("outside")){
                 break;
             }
-            int desiredTemp = zone.getEmptyTemp();
+            int desiredTemp = SimulationContext.getInstance().getEmptyRoomTemp();
             Room room = SimulationContext.getInstance().getHomeLayout().getRoomByName(roomName);
             if (room.getUsersInRoom() > 0){
-                desiredTemp = zone.getNonEmptyTemp();
+                desiredTemp = zone.getDesiredTemp();
             }
             room.setZone(zone.getName());
             switchStates(room, SimulationContext.getInstance().getOutsideTemp(), desiredTemp);
-            room.setCurrentTemp(desiredTemp);
-            room.setEmptyTemp(zone.getEmptyTemp());
-            room.setNonEmptyTemp(zone.getNonEmptyTemp());
+            room.setDesiredTemp(zone.getDesiredTemp());
             room.setPeriod1(zone.getPeriod1());
             room.setPeriod1Temp(zone.getPeriod1Temp());
             room.setPeriod2(zone.getPeriod2());
@@ -79,7 +77,6 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
     public boolean changeRoomTemp(String roomName, int newTemp) {
         Room room = SimulationContext.getInstance().getHomeLayout().getRoomByName(roomName);
         switchStates(room, room.getCurrentTemp(), newTemp);
-        room.setCurrentTemp(newTemp);
         room.setOverridden(true);
         return true;
     }
@@ -95,7 +92,6 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
         int newTemp = getPeriodTemp(rooms.get(0), period);
         for (Room room : rooms) {
             switchStates(room, room.getCurrentTemp(), newTemp);
-            room.setCurrentTemp(newTemp);
             room.setOverridden(false);
         }
         return true;
@@ -209,7 +205,6 @@ public class SmartHomeHeating extends Module implements AwayModeMonitor, Monitor
         }
         for (Room room : rooms) {
             switchStates(room, room.getCurrentTemp(), newTemp);
-            room.setCurrentTemp(newTemp);
             room.setOverridden(false);
         }
     }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeatingProxy.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeatingProxy.java
@@ -3,7 +3,7 @@ package com.project.SmartHomeSimulator.module;
 import com.project.SmartHomeSimulator.model.Role;
 import com.project.SmartHomeSimulator.model.Room;
 import com.project.SmartHomeSimulator.model.User;
-import com.project.SmartHomeSimulator.model.Zone;
+import com.project.SmartHomeSimulator.model.Zones.Zone;
 
 import java.util.ArrayList;
 

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeatingProxy.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/module/SmartHomeHeatingProxy.java
@@ -53,7 +53,7 @@ public class SmartHomeHeatingProxy {
      * @param newTemp
      * @return
      */
-    public boolean changeRoomTemp(User user, String roomName, int newTemp) {
+    public boolean changeRoomTemp(User user, String roomName, double newTemp) {
         boolean success = false;
         if (verifyPermission(user, "temp", roomName)) {
             success = smartHomeHeating.changeRoomTemp(roomName, newTemp);

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SimulationContextService.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SimulationContextService.java
@@ -2,11 +2,13 @@ package com.project.SmartHomeSimulator.service;
 
 import java.util.List;
 
+import com.project.SmartHomeSimulator.model.ResponseParameters;
 import org.springframework.stereotype.Service;
 
 import com.project.SmartHomeSimulator.model.HomeLayout;
 import com.project.SmartHomeSimulator.module.SimulationContext;
 import com.project.SmartHomeSimulator.model.User;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Service
 public class SimulationContextService {
@@ -16,8 +18,12 @@ public class SimulationContextService {
     /**
      * Start the simulation
      */
-    public void startSimulation() {
-        simulationContext.setSimulationRunning(true);
+    public ResponseParameters startSimulation() {
+        ResponseParameters response = verifyParameters();
+        if(response.allowed) {
+            simulationContext.setSimulationRunning(true);
+        }
+        return response;
     }
 
     /**
@@ -102,6 +108,31 @@ public class SimulationContextService {
     public boolean setAutoMode(boolean autoMode) {
         simulationContext.setAutoMode(autoMode);
         return true;
+    }
+
+    public ResponseParameters verifyParameters(){
+        ResponseParameters response = new ResponseParameters();
+        response.setAllowed(true);
+        response.setConsoleMessage("[Success] The simulation started!");
+        if (HomeLayout.roomsNotInZone != 0){
+            response.setAllowed(false);
+            response.setConsoleMessage("[Failed] All rooms should be in zones before starting the simulation.");
+        }
+        if (simulationContext.getTime() == null || simulationContext.getDate() == null)
+        {
+            response.setAllowed(false);
+            response.setConsoleMessage("[Failed] Date and Time should be set in simulation parameters before starting the simulation.");
+        }
+        if(simulationContext.getCurrentSimulationUser() == null){
+            response.setAllowed(false);
+            response.setConsoleMessage("[Failed] A current profile should be chosen before starting the simulation.");
+        }
+        if(simulationContext.getHomeLayout() == null){
+            response.setAllowed(false);
+            response.setConsoleMessage("[Failed] A home layout should be uploaded before starting the simulation.");
+        }
+
+        return response;
     }
 
 }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SimulationContextService.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SimulationContextService.java
@@ -47,7 +47,7 @@ public class SimulationContextService {
      * @param outsideTemp
      * @return  - true if successful false if otherwise
      */
-    public boolean setOutsideTemp(int outsideTemp) {
+    public boolean setOutsideTemp(double outsideTemp) {
         simulationContext.setOutsideTemp(outsideTemp);
         return true;
     }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingService.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingService.java
@@ -2,7 +2,7 @@ package com.project.SmartHomeSimulator.service;
 
 import com.project.SmartHomeSimulator.model.Room;
 import com.project.SmartHomeSimulator.model.User;
-import com.project.SmartHomeSimulator.model.Zone;
+import com.project.SmartHomeSimulator.model.Zones.Zone;
 import com.project.SmartHomeSimulator.model.roomObjects.RoomObjectType;
 import com.project.SmartHomeSimulator.module.SimulationContext;
 import com.project.SmartHomeSimulator.module.SmartHomeHeatingProxy;

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingService.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingService.java
@@ -100,4 +100,19 @@ public class SmartHomeHeatingService {
     public void setSeason(boolean isSummer) {
         smartHomeHeatingProxy.setSeason(isSummer);
     }
+
+    /**
+     * Set currentTemp of a room
+     * @param roomName
+     * @param currentTemp
+     * @return
+     */
+    public boolean setCurrentTemp(String roomName, int currentTemp){
+        Room room = simulationContext.getHomeLayout().getRoomByName(roomName);
+        if (room != null){
+            room.setCurrentTemp(currentTemp);
+            return true;
+        }
+        return false;
+    }
 }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingService.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingService.java
@@ -33,7 +33,7 @@ public class SmartHomeHeatingService {
      * @param newTemp
      * @return
      */
-    public boolean changeRoomTemp(String roomName, int newTemp) {
+    public boolean changeRoomTemp(String roomName, double newTemp) {
         User user = simulationContext.getCurrentSimulationUser();
         return smartHomeHeatingProxy.changeRoomTemp(user, roomName, newTemp);
     }
@@ -107,7 +107,7 @@ public class SmartHomeHeatingService {
      * @param currentTemp
      * @return
      */
-    public boolean setCurrentTemp(String roomName, int currentTemp){
+    public boolean setCurrentTemp(String roomName, double currentTemp){
         Room room = simulationContext.getHomeLayout().getRoomByName(roomName);
         if (room != null){
             room.setCurrentTemp(currentTemp);

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/UserService.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/main/java/com/project/SmartHomeSimulator/service/UserService.java
@@ -72,8 +72,8 @@ public class UserService {
                     }
                 }
                 if (simulationContext.getHomeLayout() != null) {
-
                     simulationContext.getHomeLayout().addUsersInHome(user.getHomeLocation());
+                    simulationContext.getHomeLayout().getRoomByName(user.getHomeLocation()).incrementUsersInRoom();
                     simulationContext.notifyMonitors(user);
                 }
                 return true;
@@ -95,6 +95,7 @@ public class UserService {
             simulationContext.getSimulationUsers().remove(toBeRemovedUser);
             if (simulationContext.getHomeLayout() != null) {
                 simulationContext.getHomeLayout().removeUsersInHome(toBeRemovedUser.getHomeLocation());
+                simulationContext.getHomeLayout().getRoomByName(toBeRemovedUser.getHomeLocation()).decrementUsersInRoom();
             }
             return true;
         }
@@ -102,7 +103,7 @@ public class UserService {
     }
 
     /**
-     * returns false if user was not found and true if successfully deleted
+     * returns false if user was not found and true if successfully edited
      *
      * @param name
      * @param newName
@@ -144,7 +145,9 @@ public class UserService {
             }
         }
         if (user != null && !user.getHomeLocation().equalsIgnoreCase(homeLocation)) {
+            simulationContext.getHomeLayout().getRoomByName(user.getHomeLocation()).decrementUsersInRoom();
             user.setHomeLocation(homeLocation);
+            simulationContext.getHomeLayout().getRoomByName(user.getHomeLocation()).incrementUsersInRoom();
             if (simulationContext.getHomeLayout() != null) {
                 lightsInRoom = simulationContext.getHomeLayout().allLights(user.getHomeLocation());
             }

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/test/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingServiceTest.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/test/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingServiceTest.java
@@ -1,6 +1,7 @@
 package com.project.SmartHomeSimulator.service;
 
 import com.project.SmartHomeSimulator.model.*;
+import com.project.SmartHomeSimulator.model.Zones.Zone;
 import com.project.SmartHomeSimulator.model.roomObjects.RoomObject;
 import com.project.SmartHomeSimulator.model.roomObjects.RoomObjectType;
 import com.project.SmartHomeSimulator.module.SimulationContext;
@@ -52,7 +53,8 @@ public class SmartHomeHeatingServiceTest {
         List<String> namesRoom = new ArrayList<>();
         namesRoom.add("bedroom");
         namesRoom.add("garage");
-        zone.setCurrentTemp(15);
+        zone.setEmptyTemp(15);
+        zone.setNonEmptyTemp(20);
         zone.setPeriod1("10:00");
         zone.setPeriod1Temp(20);
         zone.setRoomsInZone(namesRoom);

--- a/SmartHomeSimulatorBack/SmartHomeSimulator/src/test/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingServiceTest.java
+++ b/SmartHomeSimulatorBack/SmartHomeSimulator/src/test/java/com/project/SmartHomeSimulator/service/SmartHomeHeatingServiceTest.java
@@ -53,11 +53,11 @@ public class SmartHomeHeatingServiceTest {
         List<String> namesRoom = new ArrayList<>();
         namesRoom.add("bedroom");
         namesRoom.add("garage");
-        zone.setEmptyTemp(15);
-        zone.setNonEmptyTemp(20);
+        zone.setDesiredTemp(15);
         zone.setPeriod1("10:00");
         zone.setPeriod1Temp(20);
         zone.setRoomsInZone(namesRoom);
+        smartHomeHeatingService.setCurrentTemp("garage",15);
 
         boolean result = smartHomeHeatingService.addZone(zone);
         assertTrue(result);
@@ -73,6 +73,7 @@ public class SmartHomeHeatingServiceTest {
         setup();
         addZoneTest_8();
         boolean result = smartHomeHeatingService.changeRoomTemp("bedroom", 25);
+        smartHomeHeatingService.setCurrentTemp("bedroom",25);
         assertTrue(result);
 
         assertTrue(simulationContext.getHomeLayout().getRoomByName("bedroom").isOverridden());
@@ -110,7 +111,7 @@ public class SmartHomeHeatingServiceTest {
     public void setThreshold_12() {
         setup();
         simulationContext.setTempThreshold(0);
-        int result = simulationContext.getTempThreshold();
-        assertEquals(0, result);
+        double result = simulationContext.getTempThreshold();
+        assertEquals(0, result,0);
     }
 }


### PR DESCRIPTION
**Changes in Start simulation API:**
allowed will be true when user can start, otherwise there is a console message that tells them why they can't start
![image](https://user-images.githubusercontent.com/60263256/100970173-712e5280-3502-11eb-81b8-46e921919462.png)

**Changes in creation of a zone:**
![image](https://user-images.githubusercontent.com/60263256/101215990-bbbbe600-364c-11eb-868f-6219d9a497f0.png)

**API call to update current temp of a room** ALL TEMP IS NOW A DOUBLE
`http://localhost:8080/api/v1/simulation/setCurrentTemp?roomName=bedroom1&currentTemp=15`
![image](https://user-images.githubusercontent.com/60263256/101216254-31c04d00-364d-11eb-9acb-2dca2587e60d.png)

**New API to get the zones:**
`http://localhost:8080/api/v1/simulation/getAllZones` --> GET
![image](https://user-images.githubusercontent.com/60263256/100970336-b05ca380-3502-11eb-8c0e-f8ccd20fda4d.png)

Also, if the user sends the rooms "outside" and "backyard" to add in a zone, backend will ignore it

currentTemp of a room is only updated by front end and should be updated **before**:
- user changes home location (update for new & old location)
- user is added (update for it's home location)
- before a period is reached  (Should be called for each room in that zone)
- whenever a user wants to override a room's temperature (for that room)